### PR TITLE
remove unnecessary dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "magiclen/rocket-multipart-form-data", branch = "mast
 [dependencies]
 rocket = "0.4"
 mime = "0.3.12"
-multipart = "0.16.1"
+multipart = {version = "0.16.1", default-features = false, features = ["server"]}
 chrono = "0.4.6"
 
 [dev-dependencies]


### PR DESCRIPTION
`multipart` provides integrations for `hyper`, `iron`, `tiny_http` and `nickel`, which are just bloat for usage within `rocket`.