### PR TITLE
Ignore WouldBlock I/O error kind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ branch = "master"
 rocket = "0.4.5"
 mime = "0.3.12"
 multipart = { version = "0.17", default-features = false, features = ["server"] }
+backoff = "0.3"
 
 [dev-dependencies]
 rocket-include-static-resources = "0.9"


### PR DESCRIPTION
Hi, this change allows to fix some `WouldBlock` errors while parsing multipart data. This only relates to Rocket 0.4, 0.5 is apparently not affected.

I theory this should be fixed in either Hyper or Rocket, but Hyper is outdated and Rocket 0.4 is not very active (which I can understand), I'm looking forward to seeing 0.5 out. In the meanwhile, there is this tiny change which at least covers our issue with multipart upload.

In order to test that I used `dd if=/dev/zero bs=1000000 count=2 | pv -L 3k | curl -k 'https://localhost:8000' -v -F file=@/dev/stdin`.

Artificially limiting the bandwidth (with `pv`) is the key to reproduce the problem.

PR open to suggestions.